### PR TITLE
Update queries.js

### DIFF
--- a/scraper/db/queries.js
+++ b/scraper/db/queries.js
@@ -4,46 +4,36 @@ const conn = require('./connection');
 let queries = {};
 module.exports = queries;
 
-queries.insertRawData = function(obj) {
-  /* @param { Object : String } data fields to be inserted in db
+function defaultToEmpty(value) {
+    return value || '';
+}
+
+function defaultSpecial() {
+    return this.order || '';
+}
+
+function col(name, prop, init) {
+    return {
+        name: name,
+        prop: prop || name,
+        init: init || defaultToEmpty
+    };
+}
+
+var cs = new conn.pgp.helpers.ColumnSet([
+    col('id'), col('kingdom', col('division'), col('class'), col('family'), col('genus'), col('species')),
+    col('taxonomic_order', 'taxonomicOrder', defaultSpecial),
+    col('first_paragraph', 'firstParagraph'),
+    col('image_source', 'imageSource')],
+    {table: 'raw_data'});
+
+queries.insertRawData = function (obj) {
+    /* @param { Object : String } data fields to be inserted in db
      @return { Object : Promise } */
 
-  obj['id'] = uuid.v4();
+    obj['id'] = uuid.v4();
 
-  const fields = [
-    'id', 'kingdom', 'division', 'class', 'taxonomic_order', 'family', 'genus',
-    'species', 'first_paragraph', 'image_source'
-  ];
+    var query = conn.pgp.helpers.insert(obj, cs);
 
-  const str = `
-    INSERT INTO raw_data
-    (${fields.join(', ')})
-    VALUES
-    ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);
-  `;
-
-  const values = fields.map(camelize).map(field => {
-    if (field === 'taxonomicOrder') return defaultToEmpty(obj['order']);
-    return defaultToEmpty(obj[field]);
-  });
-
-  return conn.db.task(t => {
-    return t.none(str, values);
-  });
-}
-
-function defaultToEmpty(data) {
-  /*  @param { String | undefined }
-      @return { String } */
-
-  return data || '';
-}
-
-function camelize(str) {
-  /* @param { String } snakeCased
-     @return { String } camelized
-     quick and dirty--sorry! */
-  return str.split('_').map((subStr, i) => {
-    return (i > 0) ? subStr.slice(0,1).toUpperCase() + subStr.slice(1) : subStr;
-  }).join('');
-}
+    return conn.db.none(query);
+};

--- a/scraper/db/queries.js
+++ b/scraper/db/queries.js
@@ -21,7 +21,7 @@ function col(name, prop, init) {
 }
 
 var cs = new conn.pgp.helpers.ColumnSet([
-    col('id'), col('kingdom', col('division'), col('class'), col('family'), col('genus'), col('species')),
+    col('id'), col('kingdom'), col('division'), col('class'), col('family'), col('genus'), col('species'),
     col('taxonomic_order', 'taxonomicOrder', defaultSpecial),
     col('first_paragraph', 'firstParagraph'),
     col('image_source', 'imageSource')],


### PR DESCRIPTION
If you upgrade pg-promise to the latest, 4.2.2, then you can write such code like this. No need to camelize anything, automatic, safe insert generation, much better performance, flexible initialization/defaults. See [helpers](http://vitaly-t.github.io/pg-promise/helpers.html) namespace for more details.
